### PR TITLE
add repositories to the summary prompt

### DIFF
--- a/lib/praise.ts
+++ b/lib/praise.ts
@@ -8,4 +8,12 @@ export interface Data {
   followers: number;
   following: number;
   readme: string;
+  repositories: string;
+}
+
+export interface Repository {
+  name: string,
+  description: string,
+  stargazers: number,
+  language: string
 }

--- a/routes/api/praise/[name].ts
+++ b/routes/api/praise/[name].ts
@@ -178,6 +178,7 @@ export const handler = async (
     [
       ["github", "profile", username],
       ["github", "readme", username],
+      ["github", "repos", username],
       ["github", "praise", username],
     ].forEach(async (key) => {
       await kv.delete(key);

--- a/routes/api/praise/[name].ts
+++ b/routes/api/praise/[name].ts
@@ -104,9 +104,9 @@ const getGithubRepos = async (username: string) => {
 
   // sort in descending order by the star count
   repositories.sort((r1, r2) => r2.stargazers - r1.stargazers)
-
+  // take only top 10 projects
   repositories = repositories.slice(0, Math.min(10, repositories.length))
-
+  // create a summary of all public repositories
   const reposSummary = repositories.map(stringifyRepo).join("\n")
 
   await kv.set(["github", "repos", username], reposSummary);

--- a/routes/delete.tsx
+++ b/routes/delete.tsx
@@ -19,6 +19,12 @@ export default function DeletePage() {
           </a>
         </li>
         <li>
+          GitHub repositories information (what's visible in{" "}
+          <a href="https://api.github.com/users/Xe/repos">
+            <code>https://api.github.com/users/Xe/repos</code>)
+          </a>
+        </li>
+        <li>
           GitHub README information (what's visible in{" "}
           <a href="https://github.com/Xe/Xe">
             <code>https://github.com/Xe/Xe</code>


### PR DESCRIPTION
Hey there!

I think this is a cool project, especially after being roasted by [GitHub Roaster](https://github-roast.pages.dev/)! One thing I noticed **GitHub Roaster** did was to incorporate repositories into the summary prompt. So, I added support for it in this PR.

I tested the code with `llama3.1:8b` simply because it is a smaller model.

Here's an example of a response for fasterthanlime (not that he needs any LLM generated praise xD):

![image](https://github.com/user-attachments/assets/feed53db-0539-4528-973b-6314c41bc329)
