### PR TITLE
Fix praise to distinguish between source and forked repositories

### DIFF
--- a/lib/praise.ts
+++ b/lib/praise.ts
@@ -15,5 +15,6 @@ export interface Repository {
   name: string,
   description: string,
   stargazers: number,
-  language: string
+  language: string,
+  fork: boolean
 }

--- a/routes/api/praise/[name].ts
+++ b/routes/api/praise/[name].ts
@@ -46,12 +46,14 @@ const stringifyRepo = ({
   description,
   stargazers,
   language,
+  fork,
 }: Repository): string =>
   `{
   Project Name: ${name}
   Description: ${description}
   Stars: ${stargazers}
   Language: ${language}
+  Fork: ${fork}
 }`;
 
 const getGitHubInfo = async (username: string) => {
@@ -102,8 +104,12 @@ const getGithubRepos = async (username: string) => {
       description: repo.description,
       stargazers: repo.stargazers_count,
       language: repo.language,
+      fork: repo.fork,
     };
   });
+
+  // filter out forked repositories
+  repositories = repositories.filter(repo => !repo.fork);
 
   // sort in descending order by the star count
   repositories.sort((r1, r2) => r2.stargazers - r1.stargazers);


### PR DESCRIPTION
Fixes #6

Add filtering of forked repositories and include fork property in repository data.

* **lib/praise.ts**
  - Add a `fork` property to the `Repository` interface.

* **routes/api/praise/[name].ts**
  - Update the `getGithubRepos` function to filter out forked repositories.
  - Add a `fork` property to the `Repository` object in the `getGithubRepos` function.
  - Update the `stringifyRepo` function to include the `fork` property in the repository summary.
